### PR TITLE
chore: Go 1.25へアップグレード

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
       
       - name: Set PREVIOUS_TAG for brightmoon

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/shiroemons/go-brightmoon
 
-go 1.24
+go 1.25
 
 require golang.org/x/text v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
-golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=


### PR DESCRIPTION
## 概要
Go 1.25へのアップグレードを行います。

## 変更内容
- go.modのGoバージョンを1.24から1.25へ更新
- GitHub ActionsワークフローのGoバージョンを1.25へ更新  
- `go mod tidy`による依存関係の更新